### PR TITLE
Extend grammar with template tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ when either the major or minor version number changes,
 otherwise you are probably safe to update.
 
 
+## Unreleased
+
+* Add support for "render" tag
+
+
 ## 0.2.1 (2025-01-02)
 
 Only released to have a common reference point (code)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ otherwise you are probably safe to update.
 ## Unreleased
 
 * Add support for "comment" tag
-* Add support for "render" tag
+* Add support for "render" tag with params
 
 
 ## 0.2.1 (2025-01-02)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ when either the major or minor version number changes,
 otherwise you are probably safe to update.
 
 
-## Unreleased
+## 0.3.0 (2025-03-13)
 
 * Add support for 'EmptyDrop' objects when asserting
 * Add support for "comment" tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ otherwise you are probably safe to update.
 
 ## Unreleased
 
+* Add support for 'EmptyDrop' objects when asserting
 * Add support for "comment" tag
 * Add support for "render" tag with params
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ otherwise you are probably safe to update.
 
 ## Unreleased
 
+* Add support for "comment" tag
 * Add support for "render" tag
 
 

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject dk.emcken/wet "0.2.1"
+(defproject dk.emcken/wet "0.3.0"
   :description "Wet is a Liquid template language implementation in Clojure"
   :url "https://github.com/jacobemcken/wet"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [instaparse "1.4.9"]]
-  :jvm-opts ["-Duser.language=en_US"]
+  :jvm-opts ["-Duser.language=en_US"] ; required for "number format" test
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :sign-releases false}]])

--- a/src/wet/core.cljc
+++ b/src/wet/core.cljc
@@ -29,5 +29,6 @@
    (render transformed-template nil))
   ([transformed-template options]
    (let [context {:params (walk/stringify-keys (:params options))
-                  :filters (walk/stringify-keys (:filters options))}]
+                  :filters (walk/stringify-keys (:filters options))
+                  :templates (:templates options)}]
      (rendering/eval-template transformed-template context))))

--- a/src/wet/impl/parser.cljc
+++ b/src/wet/impl/parser.cljc
@@ -112,6 +112,7 @@
    :for-reversed nodes/->ForReversed
    :break nodes/->Break
    :continue nodes/->Continue
+   :comment nodes/->Comment
    :range-start identity
    :range-end identity
    :range nodes/->IntRange

--- a/src/wet/impl/parser.cljc
+++ b/src/wet/impl/parser.cljc
@@ -84,6 +84,7 @@
    :dq-str-set identity
    :dq-str-escape read-string*
    :string parse-string
+   :empty nodes/->EmptyDrop
    ;; Lookup
    :lookup parse-lookup
    :object-expr parse-object-expr

--- a/src/wet/impl/parser.cljc
+++ b/src/wet/impl/parser.cljc
@@ -89,6 +89,7 @@
    ;; Assignment
    :capture nodes/->Capture
    :assign nodes/->Assign
+   :render nodes/->Render
    :increment nodes/->Increment
    :decrement nodes/->Decrement
    ;; Conditions

--- a/src/wet/impl/parser.cljc
+++ b/src/wet/impl/parser.cljc
@@ -49,6 +49,9 @@
 
 (defn- parse-filter [name & args] (nodes/->Filter name args))
 
+(defn- parse-params [& params]
+  (apply hash-map params))
+
 (defn- parse-for-opts
   [& nodes]
   (letfn [(find-node [t] (first (filter (partial instance? t) nodes)))]
@@ -85,6 +88,7 @@
    :lookup parse-lookup
    :object-expr parse-object-expr
    :filter parse-filter
+   :params parse-params
    :index nodes/->CollIndex
    ;; Assignment
    :capture nodes/->Capture

--- a/src/wet/impl/parser/grammar.cljc
+++ b/src/wet/impl/parser/grammar.cljc
@@ -51,6 +51,7 @@
                      | break
                      | capture
                      | case
+                     | comment
                      | continue
                      | decrement
                      | for
@@ -60,6 +61,7 @@
                      | unless
 
   render ::= ltag <'render '> <s> string rtag
+  comment ::= ltag <'comment'> rtag body? ltag <'endcomment'> rtag
 
   (* VARIABLES *)
 

--- a/src/wet/impl/parser/grammar.cljc
+++ b/src/wet/impl/parser/grammar.cljc
@@ -56,7 +56,10 @@
                      | for
                      | if
                      | increment
+                     | render
                      | unless
+
+  render ::= ltag <'render '> <s> string rtag
 
   (* VARIABLES *)
 

--- a/src/wet/impl/parser/grammar.cljc
+++ b/src/wet/impl/parser/grammar.cljc
@@ -60,7 +60,9 @@
                      | render
                      | unless
 
-  render ::= ltag <'render '> <s> string rtag
+  (* TEMPLATES *)
+  params ::= (<s> <','> <s> token <':'> <s> object)*
+  render ::= ltag <'render '> <s> string params rtag
   comment ::= ltag <'comment'> rtag body? ltag <'endcomment'> rtag
 
   (* VARIABLES *)

--- a/src/wet/impl/parser/grammar.cljc
+++ b/src/wet/impl/parser/grammar.cljc
@@ -77,10 +77,11 @@
   (* PREDICATES *)
 
   operator ::= '==' | '!=' | '>' | '<' | '>=' | '<=' | 'contains'
+  empty ::= <'empty'>
 
   or_  ::= <s> 'or' <s>
   and_ ::= <s> 'and' <s>
-  assertion ::= object | object <s> operator <s> object
+  assertion ::= object | object <s> operator <s> (empty / object)
   or ::= and (<or_> and)*
   and ::= predicate (<and_> predicate)*
   predicate ::= or | <lparen> or <rparen> | assertion

--- a/src/wet/impl/parser/nodes.cljc
+++ b/src/wet/impl/parser/nodes.cljc
@@ -30,6 +30,8 @@
   Parent
   (children [_] [pred template]))
 
+(defrecord Comment [_body])
+
 (defrecord Continue [])
 
 (defrecord Decrement [var]

--- a/src/wet/impl/parser/nodes.cljc
+++ b/src/wet/impl/parser/nodes.cljc
@@ -90,9 +90,9 @@
   Parent
   (children [_] [start end]))
 
-(defrecord Render [template]
+(defrecord Render [template params]
   Parent
-  (children [_] [template]))
+  (children [_] [template params]))
 
 (defrecord Template [nodes]
   Parent

--- a/src/wet/impl/parser/nodes.cljc
+++ b/src/wet/impl/parser/nodes.cljc
@@ -88,6 +88,10 @@
   Parent
   (children [_] [start end]))
 
+(defrecord Render [template]
+  Parent
+  (children [_] [template]))
+
 (defrecord Template [nodes]
   Parent
   (children [_] nodes))

--- a/src/wet/impl/parser/nodes.cljc
+++ b/src/wet/impl/parser/nodes.cljc
@@ -34,6 +34,8 @@
 
 (defrecord Continue [])
 
+(defrecord EmptyDrop [])
+
 (defrecord Decrement [var]
   Parent
   (children [_] [var]))

--- a/src/wet/impl/rendering.cljc
+++ b/src/wet/impl/rendering.cljc
@@ -5,13 +5,13 @@
              #?@(:cljs [:refer [Assertion Assign Break Capture Case CollIndex
                                 Continue Decrement Filter For If Increment
                                 Lookup ObjectExpr PredicateAnd PredicateOr
-                                IntRange Template Unless]])]
+                                IntRange Render Template Unless]])]
             [wet.impl.utils :as utils])
   #?(:clj (:import (wet.impl.parser.nodes
                      Assertion Assign Break Capture Case CollIndex
                      Continue Decrement Filter For If Increment
                      Lookup ObjectExpr PredicateAnd PredicateOr
-                     IntRange Template Unless))))
+                     IntRange Render Template Unless))))
 
 (declare eval-node)
 (declare resolve-lookup)
@@ -223,6 +223,14 @@
 (defmethod eval-node For
   [node context]
   [(eval-for node context) context])
+
+(defmethod eval-node Render
+  [node context]
+  (let [template-name (:template node)]
+    (if-let [transformed-template (get-in context [:templates template-name])]
+      [(first (eval-node transformed-template context)) context]
+      (throw (ex-info "Unknown template referenced"
+                      {:template-name template-name})))))
 
 (defmethod eval-node Assign
   [node context]

--- a/src/wet/impl/rendering.cljc
+++ b/src/wet/impl/rendering.cljc
@@ -3,13 +3,13 @@
             [wet.filters :as filters]
             [wet.impl.parser.nodes
              #?@(:cljs [:refer [Assertion Assign Break Capture Case CollIndex
-                                Continue Decrement Filter For If Increment
+                                Comment Continue Decrement Filter For If Increment
                                 Lookup ObjectExpr PredicateAnd PredicateOr
                                 IntRange Render Template Unless]])]
             [wet.impl.utils :as utils])
   #?(:clj (:import (wet.impl.parser.nodes
                      Assertion Assign Break Capture Case CollIndex
-                     Continue Decrement Filter For If Increment
+                     Comment Continue Decrement Filter For If Increment
                      Lookup ObjectExpr PredicateAnd PredicateOr
                      IntRange Render Template Unless))))
 
@@ -243,6 +243,10 @@
   (let [[template _] (eval-node (:template node) context)]
     (swap! (::global-scope context) assoc (:var node) template)
     ["" context]))
+
+(defmethod eval-node Comment
+  [_node context]
+  ["" context])
 
 (defmethod eval-node Increment
   [node context]

--- a/test/wet/core_test.clj
+++ b/test/wet/core_test.clj
@@ -139,6 +139,18 @@
                            "{{ x }}"
                            "{% endraw %}")))
 
+  (testing "render"
+    (is (= "Hello World!"
+           (render "{{ greeting }} {% render \"x.html\" %}!"
+                   {:params {:greeting "Hello" :who "World"}
+                    :templates {"x.html" (core/parse "{{ who }}")}})))
+
+    ;; Code within rendered template should not have access to assigned variables
+    (is (= "World! No one"
+           (render "{% assign who = \"World\" %}{{ who }}!{% render \"x.html\" %}"
+                   {:params {}
+                    :templates {"x.html" (core/parse "{{ who }} No one")}}))))
+
   (testing "template analysis"
     (are [template expected]
       (->> template

--- a/test/wet/core_test.clj
+++ b/test/wet/core_test.clj
@@ -159,7 +159,14 @@
     (is (= "World! No one"
            (render "{% assign who = \"World\" %}{{ who }}!{% render \"x.html\" %}"
                    {:params {}
-                    :templates {"x.html" (core/parse "{{ who }} No one")}}))))
+                    :templates {"x.html" (core/parse "{{ who }} No one")}})))
+
+    ;; Notice how `foo` is being is being replaced by the template parameter
+    (is (= "\napples/oranges"
+           (render (str "{% assign my_variable = \"apples\" %}\n"
+                        "{% render \"x.html\", foo: my_variable, my_variable: \"oranges\" %}")
+                   {:params {:foo "bananas"}
+                    :templates {"x.html" (core/parse "{{ foo }}/{{ my_variable }}")}}))))
 
   (testing "template analysis"
     (are [template expected]

--- a/test/wet/core_test.clj
+++ b/test/wet/core_test.clj
@@ -139,6 +139,16 @@
                            "{{ x }}"
                            "{% endraw %}")))
 
+  (testing "comments" ; https://shopify.github.io/liquid/tags/template/#comment
+    (is (= "\n\nAnything you put between  tags\nis turned into a comment."
+           (render (str "{% assign verb = \"turned\" %}\n"
+                        "{% comment %}\n"
+                        "{% assign verb = \"converted\" %}\n"
+                        "{% endcomment %}\n"
+                        "Anything you put between {% comment %} and {% endcomment %} tags\n"
+                        "is {{ verb }} into a comment.")
+                   {:params {}}))))
+
   (testing "render"
     (is (= "Hello World!"
            (render "{{ greeting }} {% render \"x.html\" %}!"

--- a/test/wet/core_test.clj
+++ b/test/wet/core_test.clj
@@ -78,6 +78,20 @@
                 "{% when 42 %}"
                 "ok"
                 "{% endcase %}")
+      "ok" (str "{% if \"\" == empty %}"
+                "ok"
+                "{% else %}"
+                "not ok"
+                "{% endif %}")
+      ;; split in Ruby works differently, this workaround creates an empty collection
+      ;; map: "non-existing" removes the empty string inside col
+      "ok" (str "{% assign coll = \"\" | split: \",\" | map: \"non-existing\" %}"
+                "{% if coll == empty %}"
+                "ok"
+                "{% else %}"
+                "not ok"
+                "{% endif %}")
+
       "a = 52" (str "{% case a %}"
                     "{% when 41 %}"
                     "not ok"


### PR DESCRIPTION
Initial implementation of `render` tags with comma-colon syntax:
```
{% render "product", product: featured_product %}
```
Note: Skipped support for `with`, `as` and `for` on purpose to reduce implementation time - I might come back to it later.

Included support for `comment` tag:
```
{% comment %}
{% assign verb = "converted" %}
{% endcomment %}
```

Included support for the type `EmptyDrop`:
```
{% unless pages == empty %}
...
```